### PR TITLE
Use SYS_PTRACE and make tc qdisc optional

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -37,6 +37,7 @@ set -x
 
 if [ $INTERNAL -eq 0 ]; then
   exec docker run --cap-add=NET_ADMIN \
+                  --cap-add=SYS_PTRACE \
                   -e CODECOV_TOKEN=$CODECOV_TOKEN \
                   -e TRAVIS_BRANCH=$TRAVIS_BRANCH \
                   -v "$(pwd):/mk" \

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -48,9 +48,6 @@ fi
 
 env | grep -v TOKEN | sort
 
-# Make sure we don't consume too much resources by bumping latency
-tc qdisc add dev eth0 root netem delay 200ms 10ms
-
 # Select the proper build flags depending on the build type
 if [ "$BUILD_TYPE" = "asan" ]; then
   export CFLAGS="-fsanitize=address -O1 -fno-omit-frame-pointer"
@@ -84,12 +81,21 @@ else
   exit 1
 fi
 
-# Configure, make, and make check equivalent
+# Configure and make equivalent
 mkdir -p build/$BUILD_TYPE
 cd build/$BUILD_TYPE
 cmake -GNinja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE ../../
 cmake --build . -- -v
+
+# Make sure we don't consume too much resources by bumping latency. Not all
+# repositories need this feature. For them the code is commented out.
+{{.TC_DISABLED}}tc qdisc add dev eth0 root netem delay 200ms 10ms
+
+# Make check equivalent
 ctest --output-on-failure -a -j8
+
+# Stop adding latency. Commented out if we don't need it.
+{{.TC_DISABLED}}tc qdisc del dev eth0 root
 
 # Measure and possibly report the test coverage
 if [ "$BUILD_TYPE" = "coverage" ]; then
@@ -101,8 +107,19 @@ if [ "$BUILD_TYPE" = "coverage" ]; then
 fi
 `
 
+// tcDisabledString returns an empty string is if the tc utility is configured
+// to increase the latency, or a comment otherwise
+func tcDisabledString(pkginfo *pkginfo.PkgInfo) (s string) {
+	if pkginfo.DockerTcDisabled == true {
+		s = "#"
+	}
+	return
+}
+
 // writeSingleDockerScript writes a single docker script.
-func writeSingleDockerScript(pkginfo *pkginfo.PkgInfo, dirname, name, content string) {
+func writeSingleDockerScript(
+	pkginfo *pkginfo.PkgInfo, dirname, name, content string,
+) {
 	tmpl := template.Must(template.New(name).Parse(content))
 	filename := dirname + "/" + name
 	filep, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
@@ -112,6 +129,7 @@ func writeSingleDockerScript(pkginfo *pkginfo.PkgInfo, dirname, name, content st
 	defer filep.Close()
 	err = tmpl.Execute(filep, map[string]string{
 		"CONTAINER_NAME": pkginfo.Docker,
+		"TC_DISABLED": tcDisabledString(pkginfo),
 	})
 	if err != nil {
 		log.WithError(err).Fatalf("cannot write file: %s", filename)

--- a/pkginfo/pkginfo.go
+++ b/pkginfo/pkginfo.go
@@ -67,6 +67,14 @@ type PkgInfo struct {
 	// Docker is the docker container to use for running tests
 	Docker string
 
+	// DockerTcDisabled indicates whether we should disable using tc inside
+	// the container to artificially increase the latency. This is usually
+	// needed when you measure performance and is actually counterproductive
+	// otherwise, because it slows down operations and may also cause some
+	// more or less predicatable failures. The reason why this flag defaults
+	// to not disabling `tc` is to provide backward compatibility.
+	DockerTcDisabled bool `yaml:"docker_tc_disabled"`
+
 	// Dependencies are the package dependencies
 	Dependencies []string
 


### PR DESCRIPTION
This pull request contains two unrelated changes. As such, it probably makes sense _not to_ squash the result into a single commit, rather, it'd probably better to just rebase and merge.

The following is a detailed description of the changes based on the individual commit messages.

# docker: asan requires SYS_PTRACE

I'm not sure how I didn't notice this before but now, when running on my macOS system without SYS_PTRACE, I see a failure.

My sense is that this may have changed since I wrote the code of mkbuild and tested all the configurations locally.

# Allow to skip `tc qdisc` optional step

We need this functionality when testing performance. It seems that mkcollector does not work when using `tc qdisc`. I'm adding this flag so that it's possible to start opting out repositories from it.

I don't want to change behaviour tho. We'll need to add this flag to the repos where we don't want tc qdisc. Other repositories will continue to work (or not work) as it used to be before this flag.